### PR TITLE
feat: add CSV change log for Mode 3 characterization

### DIFF
--- a/scripts/reset.sh
+++ b/scripts/reset.sh
@@ -92,11 +92,17 @@ with open('$TASKS_FILE', 'w') as f:
     success "Tasks reset to pending"
 fi
 
-# ─── Step 4: Clear orchestrator log ──────────────────────────────────────────
+# ─── Step 4: Clear orchestrator log and change log ──────────────────────────
 ORCH_LOG="$ROOT_DIR/orchestrator/orchestrator.log"
 if [[ -f "$ORCH_LOG" ]]; then
     > "$ORCH_LOG"
     success "Orchestrator log cleared"
+fi
+
+CHANGES_CSV="$ROOT_DIR/projects/$PROJECT/changes.csv"
+if [[ -f "$CHANGES_CSV" ]]; then
+    rm -f "$CHANGES_CSV"
+    success "Changes CSV cleared"
 fi
 
 if $NUKE; then


### PR DESCRIPTION
## Summary
- Adds `log_file_changes()` to orchestrator that runs `git diff --name-status` after each RGR merge phase and appends rows to `projects/<project>/changes.csv`
- Tracks timestamp, task_id, phase (red/green/blue), action (A/M/D), and file path
- Blue phase diff captured before merge so the branch still exists
- `reset.sh` clears the CSV on soft reset

## Test plan
- [ ] Run a characterization session (1-2 tasks)
- [ ] Verify `changes.csv` exists with rows for each phase
- [ ] Verify `reset.sh` clears the CSV

🤖 Generated with [Claude Code](https://claude.com/claude-code)