### PR TITLE
feat: add existing PRD review mode to PM Pre-Flight

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The wizard (`new-project.sh`) presents three options:
 
 | Mode | When to use | What happens |
 |------|-------------|--------------|
-| **1. PM Pre-Flight** | You have a vague idea but no clear requirements | Claude generates a PRD from your idea, then exits. Run the wizard again with mode 2 or 3 to start building. |
+| **1. PM Pre-Flight** | You have a vague idea, or an existing PRD to refine | Claude generates a PRD from scratch or reviews/refines your existing PRD, then exits. Run the wizard again with mode 2 or 3 to start building. |
 | **2. New Project (`mode: new`)** | Greenfield code -- nothing exists yet | Classic TDD: QA writes **failing** tests, Dev writes minimum code to pass, Refactor cleans up |
 | **3. Existing Project (`mode: existing`)** | You have a working codebase that needs tests and cleanup | Characterization: QA writes tests that **PASS** against existing code, Dev verifies coverage (no source changes), Refactor modernizes legacy code |
 
@@ -62,21 +62,21 @@ The wizard (`new-project.sh`) presents three options:
 
 ### PM Pre-Flight (Optional First Step)
 
-PM Pre-Flight is a standalone preprocessing step that runs _before_ the RGR pipeline. It takes a vague idea and generates a structured Product Requirements Document (PRD):
+PM Pre-Flight is a standalone preprocessing step that runs _before_ the RGR pipeline. It either generates a PRD from scratch or reviews an existing one:
 
 ```bash
 my-orchestrator/scripts/new-project.sh
 # Select option 1: PM Pre-Flight
-# Enter your idea (e.g., "a REST API for managing book reviews")
+# Choose (a) start from scratch, or (b) review existing PRD
 ```
 
 What it does:
-1. Launches Claude Code as a PM agent (using the prompt in `docs/pm_agent.md`)
-2. Generates a strict PRD with happy paths, edge cases, and error states
+1. **From scratch**: You describe your idea, Claude generates a strict PRD with happy paths, edge cases, and error states
+2. **Review existing**: You provide a file path to your PRD, Claude reads it, discusses gaps and improvements with you, then writes the refined version
 3. Optionally saves the PRD to a project's QA mailbox as initial input
 4. **Exits** -- PM mode does not start the RGR pipeline
 
-After PM generates your PRD, run the wizard again and select mode 2 (New Project) or 3 (Existing Project) to begin the RGR cycle. The PRD in the QA mailbox gives the QA agent clear requirements to write tests against.
+After the PRD is ready, run the wizard again and select mode 2 (New Project) or 3 (Existing Project) to begin the RGR cycle. The PRD in the QA mailbox gives the QA agent clear requirements to write tests against.
 
 ## Prerequisites
 

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -18,7 +18,7 @@ mcp-bridge/index.js        MCP server exposing mailbox tools to Claude Code agen
 
 The wizard (`new-project.sh`) presents three options:
 
-1. **PM Pre-Flight** -- Launches Claude Code as a PM agent to generate a PRD from a vague idea. Standalone step that exits after generating `prd.md`. Does not start the RGR pipeline. Prompt template: `docs/pm_agent.md`.
+1. **PM Pre-Flight** -- Launches Claude Code as a PM agent to either generate a PRD from a vague idea or review/refine an existing PRD via conversation. Standalone step that exits after producing `prd.md`. Does not start the RGR pipeline. Prompt templates: `docs/pm_agent.md` (`pm_agent/CLAUDE.md` for scratch, `pm_agent_review/CLAUDE.md` for review).
 
 2. **New Project (`mode: new`)** -- Classic TDD. QA writes failing tests, Dev writes minimum code to pass, Refactor cleans up. Agent prompts loaded from `docs/NEW PROJECT PROMPTS.md`.
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -29,7 +29,9 @@ my-orchestrator/scripts/new-project.sh my-app     # skip folder prompt
 ```
 
 The wizard asks you to pick a mode:
-1. **PM Pre-Flight** -- generate a PRD from a vague idea (exits after, run wizard again for mode 2/3)
+1. **PM Pre-Flight** -- generate or review a PRD (exits after, run wizard again for mode 2/3)
+   - **Start from scratch** -- describe your idea and the PM agent generates a full PRD
+   - **Review existing PRD** -- provide a file path, the PM agent reads it, discusses gaps and improvements with you, then writes the refined version
 2. **New Project** -- classic TDD on a new codebase
 3. **Existing Project** -- characterization tests on an existing codebase
 

--- a/docs/pm_agent.md
+++ b/docs/pm_agent.md
@@ -11,3 +11,26 @@ You are an expert Technical Product Manager. Your objective is to take vague ide
 - **NO CODE:** You do not write tests or implementation code. You only write English specifications.
 - **NO AMBIGUITY:** Do not use words like "maybe," "should," or "ideally." Use "MUST," "MUST NOT," and "WILL."
 - **THE HANDOFF:** Output the complete PRD. This will be consumed by the QA Architect agent to begin the Test-Driven Development pipeline.
+
+## FILE_TARGET: pm_agent_review/CLAUDE.md
+# ROLE
+You are an expert Technical Product Manager. The user has an existing PRD that they want to discuss, refine, and finalize with you.
+
+# TASK PIPELINE
+1. **Read the PRD:** Read the existing PRD file provided below.
+2. **Discuss:** Have a conversation with the user about the PRD. Ask clarifying questions. Identify gaps, ambiguities, missing edge cases, or areas that need more detail.
+3. **Refine:** Based on the discussion, propose specific improvements. Wait for user approval before making changes.
+4. **Finalize:** Write the refined PRD to `prd.md` in this directory.
+
+# DISCUSSION GUIDELINES
+- Start by summarizing the PRD's scope and key requirements back to the user
+- Call out any sections that are vague, contradictory, or missing
+- Ask about: happy paths, edge cases, error states, acceptance criteria, non-functional requirements
+- Suggest concrete improvements with specific wording (using MUST/MUST NOT/WILL)
+- Do NOT rewrite the entire PRD without discussing changes first
+- When the user is satisfied, write the final version to `prd.md`
+
+# STRICT CONSTRAINTS
+- **NO CODE:** You do not write tests or implementation code. You only write English specifications.
+- **NO AMBIGUITY:** The final PRD must not use words like "maybe," "should," or "ideally." Use "MUST," "MUST NOT," and "WILL."
+- **THE HANDOFF:** Output the complete PRD. This will be consumed by the QA Architect agent to begin the Test-Driven Development pipeline.

--- a/scripts/new-project.sh
+++ b/scripts/new-project.sh
@@ -81,13 +81,13 @@ echo ""
 if [[ "$PROJECT_MODE" == "pm" ]]; then
     info "PM Pre-Flight mode"
     echo ""
-    echo "  Describe your idea (one paragraph):"
-    read -r -p "  > " USER_IDEA
-
-    if [[ -z "$USER_IDEA" ]]; then
-        error "Idea cannot be empty."
-        exit 1
-    fi
+    echo "  Do you have an existing PRD to review, or start from scratch?"
+    echo ""
+    echo "    a) Start from scratch -- describe your idea and generate a PRD"
+    echo "    b) Review existing PRD -- discuss and refine an existing document"
+    echo ""
+    read -r -p "  Choice [a/b]: " PM_CHOICE
+    PM_CHOICE="${PM_CHOICE:-a}"
 
     # Extract PM prompt from docs
     PM_PROMPT_FILE="$ROOT_DIR/docs/pm_agent.md"
@@ -96,13 +96,58 @@ if [[ "$PROJECT_MODE" == "pm" ]]; then
         exit 1
     fi
 
-    PM_PROMPT=$(extract_prompt "$PM_PROMPT_FILE" "pm_agent/CLAUDE.md")
-    # Replace placeholder with user idea
-    PM_PROMPT="${PM_PROMPT//\{\{USER_IDEA\}\}/$USER_IDEA}"
-
-    # Create temp working directory
     PM_TMPDIR=$(mktemp -d)
-    cat > "$PM_TMPDIR/CLAUDE.md" <<PMEOF
+
+    if [[ "$PM_CHOICE" =~ ^[Bb]$ ]]; then
+        # ─── Review existing PRD ─────────────────────────────────────────
+        echo ""
+        read -r -p "  Path to your PRD file: " PRD_INPUT_PATH
+
+        # Expand ~ to home directory
+        PRD_INPUT_PATH="${PRD_INPUT_PATH/#\~/$HOME}"
+
+        if [[ ! -f "$PRD_INPUT_PATH" ]]; then
+            error "File not found: $PRD_INPUT_PATH"
+            exit 1
+        fi
+
+        PM_PROMPT=$(extract_prompt "$PM_PROMPT_FILE" "pm_agent_review/CLAUDE.md")
+
+        # Copy PRD into temp dir so the agent can read it
+        cp "$PRD_INPUT_PATH" "$PM_TMPDIR/existing-prd.md"
+
+        cat > "$PM_TMPDIR/CLAUDE.md" <<PMEOF
+$PM_PROMPT
+
+---
+
+## Existing PRD
+Read the file \`existing-prd.md\` in this directory. This is the user's current PRD.
+
+## Process
+1. Read existing-prd.md
+2. Summarize it back to the user
+3. Discuss gaps, ambiguities, and improvements
+4. When the user is satisfied, write the final refined version to \`prd.md\`
+PMEOF
+
+        info "Launching Claude Code as PM agent (review mode)..."
+        info "PRD loaded from: $PRD_INPUT_PATH"
+    else
+        # ─── Generate from scratch ───────────────────────────────────────
+        echo ""
+        echo "  Describe your idea (one paragraph):"
+        read -r -p "  > " USER_IDEA
+
+        if [[ -z "$USER_IDEA" ]]; then
+            error "Idea cannot be empty."
+            exit 1
+        fi
+
+        PM_PROMPT=$(extract_prompt "$PM_PROMPT_FILE" "pm_agent/CLAUDE.md")
+        PM_PROMPT="${PM_PROMPT//\{\{USER_IDEA\}\}/$USER_IDEA}"
+
+        cat > "$PM_TMPDIR/CLAUDE.md" <<PMEOF
 $PM_PROMPT
 
 ---
@@ -114,7 +159,9 @@ $USER_IDEA
 Write the complete PRD to a file called \`prd.md\` in this directory.
 PMEOF
 
-    info "Launching Claude Code as PM agent..."
+        info "Launching Claude Code as PM agent..."
+    fi
+
     echo "  Working dir: $PM_TMPDIR"
     echo ""
 
@@ -123,7 +170,7 @@ PMEOF
 
     # Check for generated PRD
     if [[ -f "$PM_TMPDIR/prd.md" ]]; then
-        success "PRD generated: $PM_TMPDIR/prd.md"
+        success "PRD ready: $PM_TMPDIR/prd.md"
         echo ""
         echo "  ${BOLD}Preview (first 20 lines):${RESET}"
         head -20 "$PM_TMPDIR/prd.md" | sed 's/^/    /'


### PR DESCRIPTION
## Summary

- PM Pre-Flight (mode 1) now offers two sub-options: **(a) start from scratch** or **(b) review existing PRD**
- Option (b) accepts a file path, copies the PRD into the agent's working dir, and launches Claude Code with a review-focused prompt that reads the PRD, discusses gaps/improvements, and writes the refined version
- Added `pm_agent_review/CLAUDE.md` prompt template in `docs/pm_agent.md`
- Updated README, QUICKSTART, and CONTEXT docs to reflect both paths

## Test plan

- [ ] Run `scripts/new-project.sh`, select mode 1 (PM Pre-Flight), choose **(a) start from scratch** -- verify existing behavior unchanged
- [ ] Run `scripts/new-project.sh`, select mode 1, choose **(b) review existing PRD**, provide a file path -- verify agent reads the PRD and starts a discussion
- [ ] After review conversation, verify `prd.md` is written with refined content
- [ ] Verify save-to-mailbox prompt works after both paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)