### PR TITLE
fix: use normal permissions for PM review mode

### DIFF
--- a/scripts/new-project.sh
+++ b/scripts/new-project.sh
@@ -170,7 +170,13 @@ PMEOF
     echo ""
 
     # Launch Claude Code with PM system prompt and initial prompt
-    (cd "$PM_TMPDIR" && claude --dangerously-skip-permissions "$PM_INITIAL_PROMPT") || true
+    # Review mode: normal permissions (agent discusses first, asks before writing)
+    # Scratch mode: skip permissions (agent generates autonomously)
+    if [[ "$PM_CHOICE" == "2" ]]; then
+        (cd "$PM_TMPDIR" && claude "$PM_INITIAL_PROMPT") || true
+    else
+        (cd "$PM_TMPDIR" && claude --dangerously-skip-permissions "$PM_INITIAL_PROMPT") || true
+    fi
 
     # Check for generated PRD
     if [[ -f "$PM_TMPDIR/prd.md" ]]; then


### PR DESCRIPTION
## Summary

- Review mode (option 2) now runs with standard permissions -- agent reads the PRD and discusses it, then asks permission before writing the refined `prd.md`
- Scratch mode (option 1) keeps `--dangerously-skip-permissions` for autonomous PRD generation

## Test plan

- [ ] Mode 1, option 1 (scratch): verify agent generates PRD autonomously without prompting for permissions
- [ ] Mode 1, option 2 (review): verify agent starts in normal permission mode, reads PRD, discusses, and asks before writing

🤖 Generated with [Claude Code](https://claude.com/claude-code)