### PR TITLE
docs: add PRD import and Task Planner documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,16 +67,26 @@ PM Pre-Flight is a standalone preprocessing step that runs _before_ the RGR pipe
 ```bash
 my-orchestrator/scripts/new-project.sh
 # Select option 1: PM Pre-Flight
-# Choose (a) start from scratch, or (b) review existing PRD
+# Choose 1) start from scratch, or 2) review existing PRD
 ```
 
 What it does:
 1. **From scratch**: You describe your idea, Claude generates a strict PRD with happy paths, edge cases, and error states
 2. **Review existing**: You provide a file path to your PRD, Claude reads it, discusses gaps and improvements with you, then writes the refined version
-3. Optionally saves the PRD to a project's QA mailbox as initial input
-4. **Exits** -- PM mode does not start the RGR pipeline
+3. **Exits** -- PM mode does not start the RGR pipeline. It prints the `prd.md` path for the next step.
 
-After the PRD is ready, run the wizard again and select mode 2 (New Project) or 3 (Existing Project) to begin the RGR cycle. The PRD in the QA mailbox gives the QA agent clear requirements to write tests against.
+After the PRD is ready, run the wizard again and select mode 2 (New Project) or 3 (Existing Project). The wizard will ask if you have a PRD -- provide the path and it feeds into the **Task Planner**.
+
+### Task Planner (Automatic with PRD)
+
+When you provide a PRD in mode 2 or 3, the wizard launches an interactive **Task Planner** session:
+
+1. Claude reads your PRD and proposes a task breakdown (ordered by dependency)
+2. You discuss: adjust scope, split/merge tasks, reorder priorities
+3. When you approve, the planner writes `tasks.json` with properly scoped RGR tasks
+4. Type `/exit` to continue -- the wizard finishes setup and launches the pipeline
+
+Without a PRD, the wizard generates a sample greeting task for you to replace manually.
 
 ## Prerequisites
 
@@ -169,9 +179,11 @@ my-orchestrator/scripts/new-project.sh my-app
 ```
 
 After the wizard finishes, customize the generated files:
-1. Replace smoke-test tasks in `projects/<name>/tasks.json` with your real work
+1. Review `projects/<name>/tasks.json` -- if you provided a PRD, the Task Planner already generated real tasks; otherwise replace the sample task with your real work
 2. Fill in the `<!-- TODO -->` placeholders in `CLAUDE.md` in each worktree directory
 3. Launch with `my-orchestrator/scripts/start.sh <name>`
+
+If a PRD was provided, it's committed to the repo root as `prd.md` and all agent `CLAUDE.md` files include a section instructing them to reference it.
 
 Multiple projects can run simultaneously (each gets its own tmux session and mailbox).
 

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -24,6 +24,16 @@ The wizard (`new-project.sh`) presents three options:
 
 3. **Existing Project (`mode: existing`)** -- Characterization. QA writes tests that PASS against existing code, Dev verifies coverage (no source changes), Refactor modernizes. Agent prompts loaded from `docs/EXISTING PROJECT PROMPTS.md`. Includes interactive file/folder discovery for selecting source files to characterize.
 
+### PRD Import & Task Planner (Modes 2 and 3)
+
+After mode selection, the wizard asks "Do you have a PRD?" If yes:
+
+1. PRD is copied to the repo root as `prd.md`, committed, and merged into all worktrees
+2. An interactive **Task Planner** session launches -- Claude reads the PRD, proposes a task breakdown, discusses scope/dependencies/priorities with you, and writes `tasks.json` only after you approve
+3. All agent `CLAUDE.md` files get a PRD reference section instructing them to trace work back to PRD requirements
+
+Without a PRD, the wizard generates a sample greeting task and no PRD section is added to agent instructions.
+
 ## Git Worktree Layout
 
 Each project uses a single repo with three worktrees:

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -35,6 +35,8 @@ The wizard asks you to pick a mode:
 2. **New Project** -- classic TDD on a new codebase
 3. **Existing Project** -- characterization tests on an existing codebase
 
+For modes 2 and 3, the wizard then asks **"Do you have a PRD?"** -- if yes, provide the file path and the wizard launches an interactive **Task Planner** that reads your PRD, proposes a task breakdown, discusses it with you, and writes `tasks.json` when you approve. Type `/exit` after the planner finishes to continue setup.
+
 It then creates worktrees, config, tasks, and agent `CLAUDE.md` files. See [README > Three Modes](../README.md#three-modes) for details on when to use each.
 
 ## 4. Customize
@@ -42,13 +44,13 @@ It then creates worktrees, config, tasks, and agent `CLAUDE.md` files. See [READ
 Edit the generated files before launching:
 
 ```bash
-vi my-orchestrator/projects/<name>/tasks.json       # replace smoke-test tasks with real work
+vi my-orchestrator/projects/<name>/tasks.json       # review tasks (auto-generated from PRD, or replace sample)
 vi <your-repo>/.worktrees/qa/CLAUDE.md              # QA: test environment, credentials
 vi <your-repo>/.worktrees/dev/CLAUDE.md             # Dev: tech stack, architecture, patterns
 vi <your-repo>/.worktrees/refactor/CLAUDE.md        # Refactor: code style, guidelines
 ```
 
-Fill in the `<!-- TODO -->` placeholders the wizard left in each `CLAUDE.md`. The more project context you add, the better the agents perform.
+If you provided a PRD, `tasks.json` already has real tasks from the Task Planner and each agent `CLAUDE.md` includes a PRD reference section. Fill in the `<!-- TODO -->` placeholders the wizard left in each `CLAUDE.md`. The more project context you add, the better the agents perform.
 
 ## 5. Launch
 

--- a/docs/pm_agent.md
+++ b/docs/pm_agent.md
@@ -10,7 +10,7 @@ You are an expert Technical Product Manager. Your objective is to take vague ide
 # STRICT CONSTRAINTS
 - **NO CODE:** You do not write tests or implementation code. You only write English specifications.
 - **NO AMBIGUITY:** Do not use words like "maybe," "should," or "ideally." Use "MUST," "MUST NOT," and "WILL."
-- **THE HANDOFF:** Output the complete PRD. This will be consumed by the QA Architect agent to begin the Test-Driven Development pipeline.
+- **THE HANDOFF:** Output the complete PRD to `prd.md`. The user will then re-run the wizard (mode 2 or 3), provide this file path when asked, and a Task Planner will decompose it into RGR tasks.
 
 ## FILE_TARGET: pm_agent_review/CLAUDE.md
 # ROLE
@@ -33,4 +33,4 @@ You are an expert Technical Product Manager. The user has an existing PRD that t
 # STRICT CONSTRAINTS
 - **NO CODE:** You do not write tests or implementation code. You only write English specifications.
 - **NO AMBIGUITY:** The final PRD must not use words like "maybe," "should," or "ideally." Use "MUST," "MUST NOT," and "WILL."
-- **THE HANDOFF:** Output the complete PRD. This will be consumed by the QA Architect agent to begin the Test-Driven Development pipeline.
+- **THE HANDOFF:** Output the complete PRD to `prd.md`. The user will then re-run the wizard (mode 2 or 3), provide this file path when asked, and a Task Planner will decompose it into RGR tasks.


### PR DESCRIPTION
## Summary
- README: replace stale "saves to QA mailbox" ref, add Task Planner section, update post-wizard instructions
- QUICKSTART: add PRD import prompt and Task Planner step to mode descriptions
- CONTEXT: add PRD Import & Task Planner subsection explaining the full flow
- pm_agent.md: fix handoff description (PRD goes to Task Planner, not directly to QA)

## Context
Closeout doc audit found 4 files missing documentation for PRD import, Task Planner, and updated PM exit flow added in PRs #16-20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)